### PR TITLE
Alex / Text + Preview Fixes in Nav Editor

### DIFF
--- a/src/screens/NavigatorEditor/EditQuestionModal.jsx
+++ b/src/screens/NavigatorEditor/EditQuestionModal.jsx
@@ -26,6 +26,7 @@ const EditQuestionModal = ({ isOpen, dispatch, question: q }) => {
 
   const onClose = () => {
     dispatch({ type: "close_edit_modal" });
+    setQuestion(q);
   };
 
   return (

--- a/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
+++ b/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
@@ -637,7 +637,7 @@ const TreeEditor = () => {
                   backgroundColor="#AFB9A5"
                   style={{ margin: "10px" }}
                   size="lg"
-                  onClick={() => router.push("/navigator?id=" + treeID)}
+                  onClick={() => window.open("/navigator?id=" + treeID)}
                 >
                   Preview
                 </Button>

--- a/src/screens/NavigatorEditor/QuestionForm.jsx
+++ b/src/screens/NavigatorEditor/QuestionForm.jsx
@@ -25,7 +25,8 @@ const editOption = ({ question, optionId, text, icon, supportingText }) => {
           ...o,
           option: text !== undefined ? text : o.option,
           icon: icon || o.icon,
-          supportingText: supportingText !== undefined ? supportingText : o.supportingText,
+          supportingText:
+            supportingText !== undefined ? supportingText : o.supportingText,
         };
       }
       return o;

--- a/src/screens/NavigatorEditor/QuestionForm.jsx
+++ b/src/screens/NavigatorEditor/QuestionForm.jsx
@@ -20,11 +20,12 @@ const editOption = ({ question, optionId, text, icon, supportingText }) => {
     ...question,
     options: question.options.map((o) => {
       if (o.id === optionId) {
+        // check if undefined to differentiate from empty string for text fields
         return {
           ...o,
-          option: text || o.option,
+          option: text !== undefined ? text : o.option,
           icon: icon || o.icon,
-          supportingText: supportingText || o.supportingText,
+          supportingText: supportingText !== undefined ? supportingText : o.supportingText,
         };
       }
       return o;
@@ -81,7 +82,7 @@ const EditOption = ({
     <HStack w="100%">
       <Select
         variant="filled"
-        w="21%"
+        w="23%"
         size="sm"
         value={optionIcon || "QuestionMark"}
         onChange={handleIconChange}

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -1,11 +1,11 @@
 import { FaInstagram, FaFacebook, FaQuestion } from "react-icons/fa";
-import { GrResources, GiMedicalThermometer } from "react-icons/gr";
+import { GrResources } from "react-icons/gr";
 import { BiPlusMedical } from "react-icons/bi";
 import { CiMedicalMask } from "react-icons/ci";
 import { BsFileMedical } from "react-icons/bs";
 import { MdCancel, MdPersonPin } from "react-icons/md";
 import { AiOutlineCalendar } from "react-icons/ai";
-import { GiPersonInBed } from "react-icons/gi";
+import { GiPersonInBed, GiMedicalThermometer } from "react-icons/gi";
 import React from "react";
 
 const icons = {


### PR DESCRIPTION
## Text + Preview Nav Editor

Issue Number(s): #64 

What does this PR change and why?

- Open preview in new tab
- Fix bug where text field could not be cleared (had to do with how JS treats empty string and undefined as the same)
- Reset edited fields when modal is closed
- Make select width slightly larger so that text isn't cut off (was showing "QuestionMar")
- Fix Thermometer Icon import

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- Database change / migration to run
- Environment config change
- Breaking API change

### Related PRs

- #PRNUMBER

### How to Test

Preview:

https://user-images.githubusercontent.com/29695042/215366659-8c4eb634-fea5-4a5a-b286-bc5f2a8b0721.mov

Text Editor:

https://user-images.githubusercontent.com/29695042/215366814-13207eac-45c5-4cdf-ba81-523c889d0ffa.mp4

