### PR TITLE
fixing lock/unlock icon and last edit date display

### DIFF
--- a/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
+++ b/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
@@ -594,11 +594,20 @@ const TreeEditor = () => {
               <Button
                 size="md"
                 style={{ margin: "10px", backgroundColor: "#59784D" }}
-                onClick={() => dispatch({ type: "toggle_lock"})}
+                onClick={() => dispatch({ type: "toggle_lock" })}
               >
-                  <UnlockIcon color="white" size="lg" position="absolute" visibility= {state.locked ? "hidden" : "visible"}/>
-                  <LockIcon color="white" size="lg" position="absolute" visibility= {state.locked ? "visible" : "hidden"}/> 
-                
+                <UnlockIcon
+                  color="white"
+                  size="lg"
+                  position="absolute"
+                  visibility={state.locked ? "hidden" : "visible"}
+                />
+                <LockIcon
+                  color="white"
+                  size="lg"
+                  position="absolute"
+                  visibility={state.locked ? "visible" : "hidden"}
+                />
               </Button>
               <Button
                 backgroundColor="#AFB9A5"

--- a/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
+++ b/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
@@ -35,7 +35,7 @@ import ErrorNode from "src/components/Nodes/ErrorNode";
 import TextNode from "src/components/Nodes/TextNode";
 import { useRouter } from "next/router";
 import URLNode from "src/components/Nodes/URLNode";
-import { LockIcon, QuestionIcon } from "@chakra-ui/icons";
+import { LockIcon, QuestionIcon, UnlockIcon } from "@chakra-ui/icons";
 
 const deleteNodesAndEdges = (nodes, edges, navigationTree, questionId) => {
   const newNodes = nodes.filter(
@@ -578,7 +578,7 @@ const TreeEditor = () => {
             zIndex={2}
             cursor="pointer"
           />
-          <Text right="10%" top="170px" position="absolute">
+          <Text right="10%" top="170px" position="absolute" zIndex={999}>
             Last Saved: {lastUpdated}
           </Text>
           <Box
@@ -594,10 +594,11 @@ const TreeEditor = () => {
               <Button
                 size="md"
                 style={{ margin: "10px", backgroundColor: "#59784D" }}
-                border={state.locked ? "2px solid #F6893C" : ""}
-                onClick={() => dispatch({ type: "toggle_lock" })}
+                onClick={() => dispatch({ type: "toggle_lock"})}
               >
-                <LockIcon color="white" size="lg" />
+                  <UnlockIcon color="white" size="lg" position="absolute" visibility= {state.locked ? "hidden" : "visible"}/>
+                  <LockIcon color="white" size="lg" position="absolute" visibility= {state.locked ? "visible" : "hidden"}/> 
+                
               </Button>
               <Button
                 backgroundColor="#AFB9A5"


### PR DESCRIPTION
## PR Title/Tagline

Issue Number(s): #71 
What does this PR change and why?
unlocked icon shown on navigation editor by default, locked/unlocked shown by icons not orange highlight, last edited appears on top of existing nodes.

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- Database change / migration to run
- Environment config change
- Breaking API change

### Related PRs

- #PRNUMBER

### How to Test

1. Please add or build upon a testing card to the [Notion page](http://notion.so) and link it here
