### PR TITLE
fix bug regarding saving

### DIFF
--- a/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
+++ b/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
@@ -196,11 +196,19 @@ const reducer = (state, action) => {
     case "close_edit_modal":
       return { ...state, editModalOpen: false };
     case "node_change":
-      return {
-        ...state,
-        nodes: applyNodeChanges(action.changes, state.nodes),
-        unsavedChanges: true,
-      };
+      if (!state.firstRun) {
+        return {
+          ...state,
+          nodes: applyNodeChanges(action.changes, state.nodes),
+          firstRun: true,
+        };
+      } else {
+        return {
+          ...state,
+          nodes: applyNodeChanges(action.changes, state.nodes),
+          unsavedChanges: true,
+        };
+      }
     case "edge_change":
       return {
         ...state,
@@ -495,6 +503,13 @@ const TreeEditor = () => {
     }
   }, [openInstructions]);
 
+  // Set unsaved changes to false when page first loads
+  useEffect(() => {
+    state.unsavedChanges = false;
+    console.log(state.unsavedChanges);
+
+  }, []);
+
   // prompt the user if they try and leave with unsaved changes
   useEffect(() => {
     const warningText =
@@ -672,13 +687,13 @@ const TreeEditor = () => {
               nodeTypes={nodeTypes}
               nodes={state.nodes}
               edges={state.edges}
-              onInit={(reactFlowInstance) =>
+              onInit={(reactFlowInstance) => 
                 dispatch({ type: "set_react_flow_instance", reactFlowInstance })
               }
               onNodesChange={(changes) =>
                 dispatch({ type: "node_change", changes })
               }
-              onEdgesChange={(changes) =>
+              onEdgesChange={(changes) => 
                 dispatch({ type: "edge_change", changes })
               }
               onEdgesDelete={(edges) =>

--- a/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
+++ b/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
@@ -677,13 +677,13 @@ const TreeEditor = () => {
               nodeTypes={nodeTypes}
               nodes={state.nodes}
               edges={state.edges}
-              onInit={(reactFlowInstance) => 
+              onInit={(reactFlowInstance) =>
                 dispatch({ type: "set_react_flow_instance", reactFlowInstance })
               }
               onNodesChange={(changes) =>
                 dispatch({ type: "node_change", changes })
               }
-              onEdgesChange={(changes) => 
+              onEdgesChange={(changes) =>
                 dispatch({ type: "edge_change", changes })
               }
               onEdgesDelete={(edges) =>

--- a/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
+++ b/src/screens/NavigatorEditor/NavigatorEditorPage.jsx
@@ -196,19 +196,11 @@ const reducer = (state, action) => {
     case "close_edit_modal":
       return { ...state, editModalOpen: false };
     case "node_change":
-      if (!state.firstRun) {
-        return {
-          ...state,
-          nodes: applyNodeChanges(action.changes, state.nodes),
-          firstRun: true,
-        };
-      } else {
-        return {
-          ...state,
-          nodes: applyNodeChanges(action.changes, state.nodes),
-          unsavedChanges: true,
-        };
-      }
+      return {
+        ...state,
+        nodes: applyNodeChanges(action.changes, state.nodes),
+        // unsavedChanges: true, // disabled so dragging doesn't cause unsaved changes popup
+      };
     case "edge_change":
       return {
         ...state,
@@ -506,8 +498,6 @@ const TreeEditor = () => {
   // Set unsaved changes to false when page first loads
   useEffect(() => {
     state.unsavedChanges = false;
-    console.log(state.unsavedChanges);
-
   }, []);
 
   // prompt the user if they try and leave with unsaved changes


### PR DESCRIPTION
## PR Title/Tagline

Issue Number(s): #63 

What does this PR change and why?

* The pop-up doesn't occur if no changes have been made to the current active tree.
* The pop-up doesn't occur if the only changes made were node dragging (no changes to node data)

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- Database change / migration to run
- Environment config change
- Breaking API change

### Related PRs

- #PRNUMBER

### How to Test

1. Please add or build upon a testing card to the [Notion page](http://notion.so) and link it here
