### PR TITLE
Alex / Mobile Back Button

### DIFF
--- a/src/components/ErrorTemplate/ErrorTemplate.jsx
+++ b/src/components/ErrorTemplate/ErrorTemplate.jsx
@@ -14,7 +14,7 @@ const ErrorTemplate = (props) => {
 
   return (
     <div style={styles} id={styles.container}>
-      <div id={styles.flexRow}>
+      <div id={styles.utilsRow}>
         <div id={styles.progress}>
           <ProgressBar
             bgcolor={"#F6893C"}
@@ -30,6 +30,8 @@ const ErrorTemplate = (props) => {
             setUndoStack={props.setUndoStack}
           />
         </div>
+      </div>
+      <div id={styles.flexRow}>
         <h2 id={styles.question}>Sorry...</h2>
       </div>
       <div id={styles.result}>

--- a/src/components/ErrorTemplate/ErrorTemplate.module.css
+++ b/src/components/ErrorTemplate/ErrorTemplate.module.css
@@ -15,7 +15,7 @@
 }
 
 #question {
-    padding-bottom: 27px;
+    padding-bottom: 22px;
     text-align: center;
     margin-bottom: 0px;
     color: black;
@@ -103,9 +103,16 @@
 #flexRow {
     display: flex;
     flex-direction: row;
-    padding-top: 20px;
+    padding-top: 15px;
     justify-content: center;
     align-items: center;
+}
+
+#utilsRow {
+    display: flex;
+    align-items: center;
+    padding-top: 20px;
+    margin-top: 20px;
 }
 
 #result {
@@ -157,19 +164,6 @@
     font-size: 17px;
     font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
     margin-top: 5px;
-}
-@media screen and (max-width: 1220px) {
-    #progress {
-        display: none;
-    }
-
-}
-
-@media screen and (max-width: 1086px) {
-    #redo {
-        display: none;
-    }
-
 }
 
 @media (max-width: 500px) {

--- a/src/components/InfoTemplate/InfoTemplate.jsx
+++ b/src/components/InfoTemplate/InfoTemplate.jsx
@@ -11,7 +11,7 @@ import { BiLinkExternal } from "react-icons/bi";
 const InfoTemplate = (props) => {
   return (
     <div style={styles} id={styles.container}>
-      <div id={styles.flexRow}>
+      <div id={styles.utilsRow}>
         <div id={styles.progress}>
           <ProgressBar
             bgcolor={"#F6893C"}
@@ -27,6 +27,8 @@ const InfoTemplate = (props) => {
             setUndoStack={props.setUndoStack}
           />
         </div>
+      </div>
+      <div id={styles.flexRow}>
         <h2 id={styles.question}>
           {props.question.heading ? props.question.heading : "Information"}
         </h2>

--- a/src/components/InfoTemplate/InfoTemplate.module.css
+++ b/src/components/InfoTemplate/InfoTemplate.module.css
@@ -15,7 +15,7 @@
 }
 
 #question {
-    padding-bottom: 27px;
+    padding-bottom: 22px;
     text-align: center;
     margin-bottom: 0px;
     color: black;
@@ -103,9 +103,16 @@
 #flexRow {
     display: flex;
     flex-direction: row;
-    padding-top: 20px;
+    padding-top: 15px;
     justify-content: center;
     align-items: center;
+}
+
+#utilsRow {
+    display: flex;
+    align-items: center;
+    padding-top: 20px;
+    margin-top: 20px;
 }
 
 #result {
@@ -160,21 +167,6 @@
     text-align: center;
     margin-top: -30px;
     text-overflow: ellipsis;
-}
-
-
-@media screen and (max-width: 1220px) {
-    #progress {
-        display: none;
-    }
-
-}
-
-@media screen and (max-width: 1086px) {
-    #redo {
-        display: none;
-    }
-
 }
 
 @media (max-width: 700px) {

--- a/src/components/LeafTemplate/LeafTemplate.jsx
+++ b/src/components/LeafTemplate/LeafTemplate.jsx
@@ -11,7 +11,7 @@ import { BiLinkExternal } from "react-icons/bi";
 const LeafTemplate = (props) => {
   return (
     <div style={styles} id={styles.container}>
-      <div id={styles.flexRow}>
+      <div id={styles.utilsRow}>
         <div id={styles.progress}>
           <ProgressBar
             bgcolor={"#F6893C"}
@@ -27,6 +27,8 @@ const LeafTemplate = (props) => {
             setUndoStack={props.setUndoStack}
           />
         </div>
+      </div>
+      <div id={styles.flexRow}>
         <h2 id={styles.question}>Result</h2>
       </div>
       <div id={styles.result}>

--- a/src/components/LeafTemplate/LeafTemplate.module.css
+++ b/src/components/LeafTemplate/LeafTemplate.module.css
@@ -15,7 +15,7 @@
 }
 
 #question {
-    padding-bottom: 27px;
+    padding-bottom: 22px;
     text-align: center;
     margin-bottom: 0px;
     color: black;
@@ -103,9 +103,16 @@
 #flexRow {
     display: flex;
     flex-direction: row;
-    padding-top: 20px;
+    padding-top: 15px;
     justify-content: center;
     align-items: center;
+}
+
+#utilsRow {
+    display: flex;
+    align-items: center;
+    padding-top: 20px;
+    margin-top: 20px;
 }
 
 #result {
@@ -149,19 +156,6 @@
     font-size: 17px;
     font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
     margin-top: 5px;
-}
-@media screen and (max-width: 1220px) {
-    #progress {
-        display: none;
-    }
-
-}
-
-@media screen and (max-width: 1086px) {
-    #redo {
-        display: none;
-    }
-
 }
 
 @media (max-width: 500px) {

--- a/src/components/QuestionTemplate/QuestionTemplate.jsx
+++ b/src/components/QuestionTemplate/QuestionTemplate.jsx
@@ -36,7 +36,7 @@ const QuestionTemplate = (props) => {
 
   return (
     <div style={styles} id={styles.container}>
-      <div id={styles.flexRow}>
+      <div id={styles.utilsRow}>
         <div id={styles.progress}>
           <ProgressBar
             bgcolor={"#F6893C"}
@@ -52,6 +52,8 @@ const QuestionTemplate = (props) => {
             setUndoStack={props.setUndoStack}
           />
         </div>
+      </div>
+      <div id={styles.flexRow}>
         <h2 id={styles.question}>{props.question}</h2>
       </div>
       <div id={styles.optionContainer}>

--- a/src/components/QuestionTemplate/QuestionTemplate.module.css
+++ b/src/components/QuestionTemplate/QuestionTemplate.module.css
@@ -16,7 +16,7 @@
 }
 
 #question {
-    padding-bottom: 27px;
+    padding-bottom: 22px;
     text-align: center;
     margin-bottom: 0px;
     color: black;
@@ -116,23 +116,16 @@
 #flexRow {
     display: flex;
     flex-direction: row;
-    padding-top: 20px;
+    padding-top: 15px;
     justify-content: center;
     align-items: center;
 }
 
-@media screen and (max-width: 1220px) {
-    #progress {
-        display: none;
-    }
-
-}
-
-@media screen and (max-width: 1086px) {
-    #redo {
-        display: none;
-    }
-
+#utilsRow {
+    display: flex;
+    align-items: center;
+    padding-top: 20px;
+    margin-top: 20px;
 }
 
 @media screen and (max-width: 900px) {
@@ -140,7 +133,6 @@
         width: 80%;
         white-space:unset;
         max-height: 80px;
-        margin-bottom: 10px;
     }
 
 }


### PR DESCRIPTION
## PR Title/Tagline

Issue Number(s): #70 

What does this PR change and why?

- remove responsive styles which hid back button + status bar
- separated text + utils into different rows to prevent text overflowing with utils
- played with margins / paddings of various elements to keep overall screen height at 420px with no overflow

### Checklist

- [x]  Database schema docs have been updated or are not necessary
- [x]  Code follows design and style guidelines
- [x]  Code is commented with doc blocks
- [x]  Tests have been written and executed or are not necessary
- [x]  Latest code has been rebased from base branch (usually `develop`)
- [x]  Commits follow guidelines (concise, squashed, etc)
- [x]  Github issues have been linked in relevant commits
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### How to Test

1. Preview different types of trees and verify that all types of pages (error, info, leaf, question) with a back button still display when the screen is resized


![Screen Shot 2023-02-05 at 1 46 06 PM](https://user-images.githubusercontent.com/29695042/216838677-6f173292-17f0-490f-92de-a389371fa162.png)

![Screen Shot 2023-02-05 at 1 46 21 PM](https://user-images.githubusercontent.com/29695042/216838686-ae4e43f8-e152-4b0a-a1f7-72d37ea4fa29.png)
